### PR TITLE
refactor(docker): Change image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM node:onbuild  
+FROM xataz/node:onbuild  
 MAINTAINER "xataz <xataz@mondedie.fr>"  
 ENV REDIS_URL=redis://localhost:6379
 ENV AUTH_API_ENDPOINT=http://localhost/api/auth.php
 ENV ENV=production
 ENV COOKIES_SECRET=cbdjgjfozjshgklh679
 ENV SESSION_SECRET=hfdksoehngkfdlshj2
-
-RUN npm install -g bower gulp && gulp
 
 CMD ["npm","start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 chat:
-  image: mondedie/chat
+  image: mondediefr/chat
   # build: .
   environment:
     - AUTH_API_ENDPOINT=http://web/api/auth.php
@@ -14,7 +14,7 @@ chat:
     - web:web
 
 redis:
-  image: redis:3.0.5 
+  image: xataz/redis:3.0.5 
 
 web:
   image: nginx:1.9.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 chat:
-  image: mondediefr/chat
+  image: mondedie/chat
   # build: .
   environment:
     - AUTH_API_ENDPOINT=http://web/api/auth.php


### PR DESCRIPTION
Salut

Changement de l'image de base.

L'image du chat une fois buildé, faisais 850MB. Maintenant elle n'en fait plus que 235MB.
L'image redis passe également de 120MB à 7MB.

Une image nginx est également en cours.

Je suis plutôt fière de moi ^^.
